### PR TITLE
[feat] CustomAuthenticationProvider 정의

### DIFF
--- a/src/main/java/com/sparta/nanglangeats/domain/user/controller/dto/request/UserSignupRequest.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/user/controller/dto/request/UserSignupRequest.java
@@ -1,0 +1,16 @@
+package com.sparta.nanglangeats.domain.user.controller.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSignupRequest {
+
+	private String username;
+	private String password;
+	private String nickname;
+	private String email;
+}

--- a/src/main/java/com/sparta/nanglangeats/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.nanglangeats.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sparta.nanglangeats.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+	boolean existsByUsername(String username);
+	boolean existsByNickname(String nickname);
+	boolean existsByEmail(String email);
+}

--- a/src/main/java/com/sparta/nanglangeats/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/user/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package com.sparta.nanglangeats.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.nanglangeats.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByUsername(String username);
 	boolean existsByUsername(String username);
 	boolean existsByNickname(String nickname);
 	boolean existsByEmail(String email);

--- a/src/main/java/com/sparta/nanglangeats/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.sparta.nanglangeats.domain.user.controller.dto.request.UserSignupRequ
 import com.sparta.nanglangeats.domain.user.entity.User;
 import com.sparta.nanglangeats.domain.user.enums.UserRole;
 import com.sparta.nanglangeats.domain.user.repository.UserRepository;
+import com.sparta.nanglangeats.global.common.exception.CustomException;
 import com.sparta.nanglangeats.global.common.exception.CustomFieldError;
 import com.sparta.nanglangeats.global.common.exception.ParameterException;
 
@@ -30,15 +31,20 @@ public class UserService {
 		validateUserInfo(request);
 
 		return userRepository.save(User.builder()
-			.username(request.getUsername())
-			.password(passwordEncoder.encode(request.getPassword()))
-			.nickname(request.getNickname())
-			.email(request.getEmail())
-			.role(role)
-			.build())
+				.username(request.getUsername())
+				.password(passwordEncoder.encode(request.getPassword()))
+				.nickname(request.getNickname())
+				.email(request.getEmail())
+				.role(role)
+				.build())
 			.getId();
 	}
 
+	@Transactional(readOnly = true)
+	public User getUserByUsername(String username) {
+		return userRepository.findByUsername(username)
+			.orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+	}
 
 	private void validateUserInfo(UserSignupRequest request) {
 		List<CustomFieldError> customFieldErrors = new ArrayList<>();

--- a/src/main/java/com/sparta/nanglangeats/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/user/service/UserService.java
@@ -1,0 +1,81 @@
+package com.sparta.nanglangeats.domain.user.service;
+
+import static com.sparta.nanglangeats.global.common.exception.ErrorCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.nanglangeats.domain.user.controller.dto.request.UserSignupRequest;
+import com.sparta.nanglangeats.domain.user.entity.User;
+import com.sparta.nanglangeats.domain.user.enums.UserRole;
+import com.sparta.nanglangeats.domain.user.repository.UserRepository;
+import com.sparta.nanglangeats.global.common.exception.CustomFieldError;
+import com.sparta.nanglangeats.global.common.exception.ParameterException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Transactional
+	public Long insertUser(UserSignupRequest request, UserRole role) {
+		validateUserInfo(request);
+
+		return userRepository.save(User.builder()
+			.username(request.getUsername())
+			.password(passwordEncoder.encode(request.getPassword()))
+			.nickname(request.getNickname())
+			.email(request.getEmail())
+			.role(role)
+			.build())
+			.getId();
+	}
+
+
+	private void validateUserInfo(UserSignupRequest request) {
+		List<CustomFieldError> customFieldErrors = new ArrayList<>();
+
+		if (isNotUniqueUsername(request.getUsername())) {
+			customFieldErrors.add(new CustomFieldError(request.getUsername(), DUPLICATED_USERNAME));
+		}
+
+		if (isNotUniqueNickname(request.getNickname())) {
+			customFieldErrors.add(new CustomFieldError(request.getNickname(), DUPLICATED_NICKNAME));
+		}
+
+		if (isNotUniqueEmail(request.getEmail())) {
+			customFieldErrors.add(new CustomFieldError(request.getEmail(), DUPLICATED_EMAIL));
+		}
+
+		if (hasError(customFieldErrors)) {
+			throw new ParameterException(COMMON_INVALID_PARAMETER, customFieldErrors);
+		}
+	}
+
+	@Transactional(readOnly = true)
+	protected boolean isNotUniqueUsername(String username) {
+		return userRepository.existsByUsername(username);
+	}
+
+	@Transactional(readOnly = true)
+	protected boolean isNotUniqueNickname(String nickname) {
+		return userRepository.existsByNickname(nickname);
+	}
+
+	@Transactional(readOnly = true)
+	protected boolean isNotUniqueEmail(String email) {
+		return userRepository.existsByEmail(email);
+	}
+
+	private boolean hasError(List<CustomFieldError> customFieldErrors) {
+		return !customFieldErrors.isEmpty();
+	}
+}

--- a/src/main/java/com/sparta/nanglangeats/global/common/exception/CustomFieldError.java
+++ b/src/main/java/com/sparta/nanglangeats/global/common/exception/CustomFieldError.java
@@ -1,0 +1,15 @@
+package com.sparta.nanglangeats.global.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomFieldError {
+
+	private final String rejectedValue;
+	private final String errorMessage;
+
+	public CustomFieldError(String rejectedValue, ErrorCode errorCode) {
+		this.rejectedValue = rejectedValue;
+		this.errorMessage = errorCode.getMessage();
+	}
+}

--- a/src/main/java/com/sparta/nanglangeats/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/nanglangeats/global/common/exception/ErrorCode.java
@@ -18,10 +18,13 @@ public enum ErrorCode {
     CARD_ACCESS_FORBIDDEN(FORBIDDEN, "카드 작성자 및 매니저만 접근할 수 있습니다."),
 
     // User
+    INVALID_PASSWORD(BAD_REQUEST, "유효하지 않은 비밀번호입니다"),
+
     DUPLICATED_USERNAME(BAD_REQUEST, "이미 존재하는 사용자 아이디입니다."),
     DUPLICATED_NICKNAME(BAD_REQUEST, "이미 존재하는 사용자 유저네임입니다."),
     DUPLICATED_EMAIL(BAD_REQUEST, "이미 존재하는 사용자 이메일입니다."),
 
+    USER_NOT_FOUND(NOT_FOUND, "유저를 찾을 수 없습니다."),
     // Order
 
     // Review

--- a/src/main/java/com/sparta/nanglangeats/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/nanglangeats/global/common/exception/ErrorCode.java
@@ -10,12 +10,17 @@ import static org.springframework.http.HttpStatus.*;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    // COMMON
+    COMMON_INVALID_PARAMETER(BAD_REQUEST, "요청한 값이 올바르지 않습니다."),
+
     // JWT
     INVALID_REFRESH_TOKEN(UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다. 다시 로그인 해주세요."),
     CARD_ACCESS_FORBIDDEN(FORBIDDEN, "카드 작성자 및 매니저만 접근할 수 있습니다."),
 
     // User
     DUPLICATED_USERNAME(BAD_REQUEST, "이미 존재하는 사용자 아이디입니다."),
+    DUPLICATED_NICKNAME(BAD_REQUEST, "이미 존재하는 사용자 유저네임입니다."),
+    DUPLICATED_EMAIL(BAD_REQUEST, "이미 존재하는 사용자 이메일입니다."),
 
     // Order
 

--- a/src/main/java/com/sparta/nanglangeats/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/nanglangeats/global/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.sparta.nanglangeats.global.common.exception;
 
+import java.util.List;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -10,25 +10,40 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(CustomException.class)
-    public ResponseEntity<?> handleScheduleException(CustomException e) {
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-                .body(new ExceptionDto(e.getErrorCode()));
-    }
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<?> handleCustomException(CustomException e) {
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+			.body(new ExceptionDto(e.getErrorCode()));
+	}
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<?> handleException(MethodArgumentNotValidException e){
-        BindingResult bindingResult = e.getBindingResult();
-        StringBuilder builder = new StringBuilder();
+	@ExceptionHandler(ParameterException.class)
+	public ResponseEntity<?> handleParameterException(ParameterException e) {
+		List<CustomFieldError> customFieldErrors = e.getCustomFieldErrors();
+		StringBuilder builder = new StringBuilder();
 
-        for (FieldError fieldError : bindingResult.getFieldErrors()) {
-            builder.append(fieldError.getField()).append(" : ")
-                    .append(fieldError.getDefaultMessage()).append("\n");
-        }
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionDto(builder.toString()));
-    }
+		for (CustomFieldError customFieldError : customFieldErrors) {
+			builder.append(customFieldError.getRejectedValue()).append(" : ")
+				.append(customFieldError.getErrorMessage()).append("\n");
+		}
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionDto(builder.toString()));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<?> handleException(MethodArgumentNotValidException e) {
+		BindingResult bindingResult = e.getBindingResult();
+		StringBuilder builder = new StringBuilder();
+
+		for (FieldError fieldError : bindingResult.getFieldErrors()) {
+			builder.append(fieldError.getField()).append(" : ")
+				.append(fieldError.getDefaultMessage()).append("\n");
+		}
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionDto(builder.toString()));
+	}
 }

--- a/src/main/java/com/sparta/nanglangeats/global/common/exception/ParameterException.java
+++ b/src/main/java/com/sparta/nanglangeats/global/common/exception/ParameterException.java
@@ -1,0 +1,16 @@
+package com.sparta.nanglangeats.global.common.exception;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class ParameterException extends CustomException {
+
+	private final List<CustomFieldError> customFieldErrors;
+
+	public ParameterException(ErrorCode errorCode, List<CustomFieldError> customFieldErrors) {
+		super(errorCode);
+		this.customFieldErrors = customFieldErrors;
+	}
+}

--- a/src/main/java/com/sparta/nanglangeats/global/config/AuthConfig.java
+++ b/src/main/java/com/sparta/nanglangeats/global/config/AuthConfig.java
@@ -1,0 +1,13 @@
+package com.sparta.nanglangeats.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AuthConfig {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+}

--- a/src/main/java/com/sparta/nanglangeats/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/nanglangeats/global/config/SecurityConfig.java
@@ -2,26 +2,37 @@ package com.sparta.nanglangeats.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final AuthenticationProvider authenticationProvider;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
 		return http
 			.httpBasic(AbstractHttpConfigurer::disable)
-			.formLogin(AbstractHttpConfigurer::disable)
 			.csrf(AbstractHttpConfigurer::disable)
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.formLogin(form -> form
+				.loginProcessingUrl("/api/auth/login").permitAll()
+			)
+
 			.authorizeHttpRequests(requests -> requests
-				.requestMatchers("/api/auth/login").permitAll()
 				.anyRequest().authenticated())
+
+			.authenticationProvider(authenticationProvider)
 			.build();
 	}
 }

--- a/src/main/java/com/sparta/nanglangeats/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/nanglangeats/global/config/SecurityConfig.java
@@ -1,4 +1,27 @@
 package com.sparta.nanglangeats.global.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(requests -> requests
+				.requestMatchers("/api/auth/login").permitAll()
+				.anyRequest().authenticated())
+			.build();
+	}
 }

--- a/src/main/java/com/sparta/nanglangeats/global/config/security/provider/CustomAuthenticationProvider.java
+++ b/src/main/java/com/sparta/nanglangeats/global/config/security/provider/CustomAuthenticationProvider.java
@@ -1,0 +1,49 @@
+package com.sparta.nanglangeats.global.config.security.provider;
+
+import static com.sparta.nanglangeats.global.common.exception.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.sparta.nanglangeats.domain.user.entity.User;
+import com.sparta.nanglangeats.domain.user.service.UserService;
+import com.sparta.nanglangeats.global.common.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+	private final UserService userService;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+		String username = authentication.getName();
+		String password = (String) authentication.getCredentials();
+
+		User user = userService.getUserByUsername(username);
+		checkPassword(password, user);
+
+		return new UsernamePasswordAuthenticationToken(user, null, List.of(new SimpleGrantedAuthority(user.getRole().getAuthority())));
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return authentication.isAssignableFrom(UsernamePasswordAuthenticationToken.class);
+	}
+
+	private void checkPassword(String password, User user) {
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw new CustomException(INVALID_PASSWORD);
+		}
+	}
+}

--- a/src/test/java/com/sparta/nanglangeats/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/sparta/nanglangeats/domain/user/repository/UserRepositoryTest.java
@@ -2,6 +2,8 @@ package com.sparta.nanglangeats.domain.user.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,28 @@ class UserRepositoryTest {
 
 	@Autowired
 	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("findByUsername(유저네임): 유저네임을 받아 사용자를 조회한다.")
+	void findByUsername() {
+		// given
+		final String username = "tester";
+		final String nickname = "tester";
+		final String email = "tester";
+		final UserRole role = UserRole.CUSTOMER;
+
+		saveUser(username, nickname, email, role);
+
+		// when
+		Optional<User> result = userRepository.findByUsername(username);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().getUsername()).isEqualTo(username);
+		assertThat(result.get().getNickname()).isEqualTo(nickname);
+		assertThat(result.get().getEmail()).isEqualTo(email);
+	}
+
 
 	@Test
 	@DisplayName("existsByUsername(유저네임): 유저네임을 받아 사용자가 존재하는지 확인한다.")

--- a/src/test/java/com/sparta/nanglangeats/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/sparta/nanglangeats/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.sparta.nanglangeats.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.nanglangeats.domain.user.entity.User;
+import com.sparta.nanglangeats.domain.user.enums.UserRole;
+
+@Transactional
+@SpringBootTest
+class UserRepositoryTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("existsByUsername(유저네임): 유저네임을 받아 사용자가 존재하는지 확인한다.")
+	void existsByUsername() {
+		// given
+		final String username = "tester";
+		final String nickname = "tester";
+		final String email = "tester";
+		final UserRole role = UserRole.CUSTOMER;
+
+		saveUser(username, nickname, email, role);
+
+		// when
+		boolean result = userRepository.existsByUsername(username);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("existsByNickname(닉네임): 닉네임을 받아 존재하는지 확인한다.")
+	void existsByNickname() {
+		// given
+		final String username = "tester";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		final UserRole role = UserRole.CUSTOMER;
+
+		saveUser(username, nickname, email, role);
+
+		// when
+		boolean result = userRepository.existsByNickname(nickname);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("existsByEmail(이메일): 이메일을 받아 존재하는지 확인한다.")
+	void existsByEmail() {
+		// given
+		final String username = "tester";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		final UserRole role = UserRole.CUSTOMER;
+
+		saveUser(username, nickname, email, role);
+
+		// when
+		boolean result = userRepository.existsByEmail(email);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	private User saveUser(String username, String nickname, String email, UserRole role) {
+		return userRepository.save(User.builder()
+			.username(username)
+			.password("password")
+			.nickname(nickname)
+			.email(email)
+			.role(role)
+			.build());
+	}
+}

--- a/src/test/java/com/sparta/nanglangeats/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/nanglangeats/domain/user/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import com.sparta.nanglangeats.domain.user.controller.dto.request.UserSignupRequ
 import com.sparta.nanglangeats.domain.user.entity.User;
 import com.sparta.nanglangeats.domain.user.enums.UserRole;
 import com.sparta.nanglangeats.domain.user.repository.UserRepository;
+import com.sparta.nanglangeats.global.common.exception.CustomException;
 import com.sparta.nanglangeats.global.common.exception.CustomFieldError;
 import com.sparta.nanglangeats.global.common.exception.ParameterException;
 
@@ -164,6 +165,43 @@ class UserServiceTest {
 				tuple(duplicatedEmail, DUPLICATED_EMAIL.getMessage())
 			);
 	}
+
+	@Test
+	@DisplayName("getUserByUsername(유저네임): 유저네임을 받아 사용자를 조회한다.")
+	void getUserByUsername_success() {
+		// given
+		final String username = "testerId";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		saveUser(username, nickname, email);
+
+		// when
+		User result = userService.getUserByUsername(username);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getUsername()).isEqualTo(username);
+		assertThat(result.getNickname()).isEqualTo(nickname);
+		assertThat(result.getEmail()).isEqualTo(email);
+	}
+
+	@Test
+	@DisplayName("getUserByUsername(유저네임): 유저네임이 존재하지 않는 경우 조회에 실패한다.")
+	void getUserByUsername_does_not_exist_username_fail() {
+		// given
+		final String username = "testerId";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		saveUser(username, nickname, email);
+
+		final String newUsername = "newUsername";
+
+		// expected
+		assertThatThrownBy(() -> userService.getUserByUsername(newUsername))
+			.isInstanceOf(CustomException.class)
+			.hasMessage(USER_NOT_FOUND.getMessage());
+	}
+
 	
 	private User saveUser(String username, String nickname, String email) {
 		return userRepository.save(User.builder()

--- a/src/test/java/com/sparta/nanglangeats/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/nanglangeats/domain/user/service/UserServiceTest.java
@@ -1,0 +1,177 @@
+package com.sparta.nanglangeats.domain.user.service;
+
+import static com.sparta.nanglangeats.global.common.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.nanglangeats.domain.user.controller.dto.request.UserSignupRequest;
+import com.sparta.nanglangeats.domain.user.entity.User;
+import com.sparta.nanglangeats.domain.user.enums.UserRole;
+import com.sparta.nanglangeats.domain.user.repository.UserRepository;
+import com.sparta.nanglangeats.global.common.exception.CustomFieldError;
+import com.sparta.nanglangeats.global.common.exception.ParameterException;
+
+@Transactional
+@SpringBootTest
+class UserServiceTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Test
+	@DisplayName("insertUser(회원가입DTO, 유저역할): 회원가입 정보와 유저 역할을 입력받아서 유저를 생성한다.")
+	void insertUser_success() {
+		// given
+		final UserSignupRequest request = new UserSignupRequest("testerId", "password", "tester", "test@gmail.com");
+		final UserRole role = UserRole.CUSTOMER;
+
+		// when
+		final Long userId = userService.insertUser(request, role);
+
+		// then
+		final Optional<User> result = userRepository.findById(userId);
+
+		assertThat(result.isPresent()).isTrue();
+		assertThat(result.get().getUsername()).isEqualTo(request.getUsername());
+		assertThat(passwordEncoder.matches(request.getPassword(), result.get().getPassword())).isTrue();
+		assertThat(result.get().getNickname()).isEqualTo(request.getNickname());
+		assertThat(result.get().getEmail()).isEqualTo(request.getEmail());
+		assertThat(result.get().getRole()).isEqualTo(role);
+	}
+
+	@Test
+	@DisplayName("insertUser(회원가입DTO, 유저역할): 회원가입 DTO의 유저네임이 중복되면 유저 생성을 실패한다.")
+	void insertUser_duplicated_username_fail() {
+		// given
+		final String username = "testerId";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		saveUser(username, nickname, email);
+
+		final String duplicatedUsername = "testerId";
+		final String password2 = "password";
+		final String nickname2 = "tester2";
+		final String email2 = "tester2@gmail.com";
+		final UserRole role = UserRole.CUSTOMER;
+		final UserSignupRequest request = new UserSignupRequest(duplicatedUsername, password2, nickname2, email2);
+
+		// expected
+		assertThatThrownBy(() -> userService.insertUser(request, role))
+			.isInstanceOf(ParameterException.class)
+			.hasMessage(COMMON_INVALID_PARAMETER.getMessage())
+			.extracting("customFieldErrors")
+			.asInstanceOf(InstanceOfAssertFactories.list(CustomFieldError.class))
+			.hasSize(1)
+			.extracting("rejectedValue", "errorMessage")
+			.containsExactly(tuple(duplicatedUsername, DUPLICATED_USERNAME.getMessage()));
+	}
+
+	@Test
+	@DisplayName("insertUser(회원가입DTO, 유저역할): 회원가입 DTO의 닉네임이 중복되면 유저 생성을 실패한다.")
+	void insertUser_duplicated_nickname_fail() {
+		// given
+		final String username = "testerId";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		saveUser(username, nickname, email);
+
+		final String username2 = "testerId2";
+		final String password2 = "password";
+		final String duplicatedNickname = "tester";
+		final String email2 = "tester2@gmail.com";
+		final UserRole role = UserRole.CUSTOMER;
+		final UserSignupRequest request = new UserSignupRequest(username2, password2, duplicatedNickname, email2);
+
+		// expected
+		assertThatThrownBy(() -> userService.insertUser(request, role))
+			.isInstanceOf(ParameterException.class)
+			.hasMessage(COMMON_INVALID_PARAMETER.getMessage())
+			.extracting("customFieldErrors")
+			.asInstanceOf(InstanceOfAssertFactories.list(CustomFieldError.class))
+			.hasSize(1)
+			.extracting("rejectedValue", "errorMessage")
+			.containsExactly(tuple(duplicatedNickname, DUPLICATED_NICKNAME.getMessage()));
+	}
+
+	@Test
+	@DisplayName("insertUser(회원가입DTO, 유저역할): 회원가입 DTO의 이메일이 중복되면 유저 생성을 실패한다.")
+	void insertUser_duplicated_email_fail() {
+		// given
+		final String username = "testerId";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		saveUser(username, nickname, email);
+
+		final String username2 = "testerId2";
+		final String password2 = "password";
+		final String nickname2 = "tester2";
+		final String duplicatedEmail = "tester@gmail.com";
+		final UserRole role = UserRole.CUSTOMER;
+		final UserSignupRequest request = new UserSignupRequest(username2, password2, nickname2, duplicatedEmail);
+
+		// expected
+		assertThatThrownBy(() -> userService.insertUser(request, role))
+			.isInstanceOf(ParameterException.class)
+			.hasMessage(COMMON_INVALID_PARAMETER.getMessage())
+			.extracting("customFieldErrors")
+			.asInstanceOf(InstanceOfAssertFactories.list(CustomFieldError.class))
+			.hasSize(1)
+			.extracting("rejectedValue", "errorMessage")
+			.containsExactly(tuple(duplicatedEmail, DUPLICATED_EMAIL.getMessage()));
+	}
+
+	@Test
+	@DisplayName("insertUser(회원가입DTO, 유저역할): 회원가입 DTO의 여러 필드가 중복되면 유저 생성을 실패한다.")
+	void insertUser_multiple_duplicated_info_fail() {
+		// given
+		final String username = "testerId";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		saveUser(username, nickname, email);
+
+		final String duplicatedUsername = "testerId";
+		final String password2 = "password";
+		final String nickname2 = "tester2";
+		final String duplicatedEmail = "tester@gmail.com";
+		final UserRole role = UserRole.CUSTOMER;
+		final UserSignupRequest request = new UserSignupRequest(duplicatedUsername, password2, nickname2, duplicatedEmail);
+
+		// expected
+		assertThatThrownBy(() -> userService.insertUser(request, role))
+			.isInstanceOf(ParameterException.class)
+			.hasMessage(COMMON_INVALID_PARAMETER.getMessage())
+			.extracting("customFieldErrors")
+			.asInstanceOf(InstanceOfAssertFactories.list(CustomFieldError.class))
+			.hasSize(2)
+			.extracting("rejectedValue", "errorMessage")
+			.containsExactly(
+				tuple(duplicatedUsername, DUPLICATED_USERNAME.getMessage()),
+				tuple(duplicatedEmail, DUPLICATED_EMAIL.getMessage())
+			);
+	}
+	
+	private User saveUser(String username, String nickname, String email) {
+		return userRepository.save(User.builder()
+			.username(username)
+			.password("password")
+			.nickname(nickname)
+			.email(email)
+			.role(UserRole.CUSTOMER)
+			.build());
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13

## 📝작업 내용

- CustomAuthenticationProvider 정의
- UserRepository, UserService 유저 조회 기능 추가 및 테스트 코드 구현
- HttpSecurity에 CustomAuthenticationProvider 등록

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
