### PR TITLE
[feat] CustomAuthenticationProvider 정의

### DIFF
--- a/src/main/java/com/sparta/nanglangeats/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/user/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package com.sparta.nanglangeats.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.nanglangeats.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByUsername(String username);
 	boolean existsByUsername(String username);
 	boolean existsByNickname(String nickname);
 	boolean existsByEmail(String email);

--- a/src/main/java/com/sparta/nanglangeats/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.sparta.nanglangeats.domain.user.controller.dto.request.UserSignupRequ
 import com.sparta.nanglangeats.domain.user.entity.User;
 import com.sparta.nanglangeats.domain.user.enums.UserRole;
 import com.sparta.nanglangeats.domain.user.repository.UserRepository;
+import com.sparta.nanglangeats.global.common.exception.CustomException;
 import com.sparta.nanglangeats.global.common.exception.CustomFieldError;
 import com.sparta.nanglangeats.global.common.exception.ParameterException;
 
@@ -30,15 +31,20 @@ public class UserService {
 		validateUserInfo(request);
 
 		return userRepository.save(User.builder()
-			.username(request.getUsername())
-			.password(passwordEncoder.encode(request.getPassword()))
-			.nickname(request.getNickname())
-			.email(request.getEmail())
-			.role(role)
-			.build())
+				.username(request.getUsername())
+				.password(passwordEncoder.encode(request.getPassword()))
+				.nickname(request.getNickname())
+				.email(request.getEmail())
+				.role(role)
+				.build())
 			.getId();
 	}
 
+	@Transactional(readOnly = true)
+	public User getUserByUsername(String username) {
+		return userRepository.findByUsername(username)
+			.orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+	}
 
 	private void validateUserInfo(UserSignupRequest request) {
 		List<CustomFieldError> customFieldErrors = new ArrayList<>();

--- a/src/main/java/com/sparta/nanglangeats/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/nanglangeats/global/common/exception/ErrorCode.java
@@ -18,10 +18,13 @@ public enum ErrorCode {
     CARD_ACCESS_FORBIDDEN(FORBIDDEN, "카드 작성자 및 매니저만 접근할 수 있습니다."),
 
     // User
+    INVALID_PASSWORD(BAD_REQUEST, "유효하지 않은 비밀번호입니다"),
+
     DUPLICATED_USERNAME(BAD_REQUEST, "이미 존재하는 사용자 아이디입니다."),
     DUPLICATED_NICKNAME(BAD_REQUEST, "이미 존재하는 사용자 유저네임입니다."),
     DUPLICATED_EMAIL(BAD_REQUEST, "이미 존재하는 사용자 이메일입니다."),
 
+    USER_NOT_FOUND(NOT_FOUND, "유저를 찾을 수 없습니다."),
     // Order
 
     // Review

--- a/src/main/java/com/sparta/nanglangeats/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/nanglangeats/global/config/SecurityConfig.java
@@ -2,26 +2,37 @@ package com.sparta.nanglangeats.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final AuthenticationProvider authenticationProvider;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
 		return http
 			.httpBasic(AbstractHttpConfigurer::disable)
-			.formLogin(AbstractHttpConfigurer::disable)
 			.csrf(AbstractHttpConfigurer::disable)
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.formLogin(form -> form
+				.loginProcessingUrl("/api/auth/login").permitAll()
+			)
+
 			.authorizeHttpRequests(requests -> requests
-				.requestMatchers("/api/auth/login").permitAll()
 				.anyRequest().authenticated())
+
+			.authenticationProvider(authenticationProvider)
 			.build();
 	}
 }

--- a/src/main/java/com/sparta/nanglangeats/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/nanglangeats/global/config/SecurityConfig.java
@@ -1,4 +1,27 @@
 package com.sparta.nanglangeats.global.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(requests -> requests
+				.requestMatchers("/api/auth/login").permitAll()
+				.anyRequest().authenticated())
+			.build();
+	}
 }

--- a/src/main/java/com/sparta/nanglangeats/global/config/security/provider/CustomAuthenticationProvider.java
+++ b/src/main/java/com/sparta/nanglangeats/global/config/security/provider/CustomAuthenticationProvider.java
@@ -1,0 +1,49 @@
+package com.sparta.nanglangeats.global.config.security.provider;
+
+import static com.sparta.nanglangeats.global.common.exception.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.sparta.nanglangeats.domain.user.entity.User;
+import com.sparta.nanglangeats.domain.user.service.UserService;
+import com.sparta.nanglangeats.global.common.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+	private final UserService userService;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+		String username = authentication.getName();
+		String password = (String) authentication.getCredentials();
+
+		User user = userService.getUserByUsername(username);
+		checkPassword(password, user);
+
+		return new UsernamePasswordAuthenticationToken(user, null, List.of(new SimpleGrantedAuthority(user.getRole().getAuthority())));
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return authentication.isAssignableFrom(UsernamePasswordAuthenticationToken.class);
+	}
+
+	private void checkPassword(String password, User user) {
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw new CustomException(INVALID_PASSWORD);
+		}
+	}
+}

--- a/src/test/java/com/sparta/nanglangeats/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/sparta/nanglangeats/domain/user/repository/UserRepositoryTest.java
@@ -2,6 +2,8 @@ package com.sparta.nanglangeats.domain.user.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,28 @@ class UserRepositoryTest {
 
 	@Autowired
 	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("findByUsername(유저네임): 유저네임을 받아 사용자를 조회한다.")
+	void findByUsername() {
+		// given
+		final String username = "tester";
+		final String nickname = "tester";
+		final String email = "tester";
+		final UserRole role = UserRole.CUSTOMER;
+
+		saveUser(username, nickname, email, role);
+
+		// when
+		Optional<User> result = userRepository.findByUsername(username);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().getUsername()).isEqualTo(username);
+		assertThat(result.get().getNickname()).isEqualTo(nickname);
+		assertThat(result.get().getEmail()).isEqualTo(email);
+	}
+
 
 	@Test
 	@DisplayName("existsByUsername(유저네임): 유저네임을 받아 사용자가 존재하는지 확인한다.")

--- a/src/test/java/com/sparta/nanglangeats/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/nanglangeats/domain/user/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import com.sparta.nanglangeats.domain.user.controller.dto.request.UserSignupRequ
 import com.sparta.nanglangeats.domain.user.entity.User;
 import com.sparta.nanglangeats.domain.user.enums.UserRole;
 import com.sparta.nanglangeats.domain.user.repository.UserRepository;
+import com.sparta.nanglangeats.global.common.exception.CustomException;
 import com.sparta.nanglangeats.global.common.exception.CustomFieldError;
 import com.sparta.nanglangeats.global.common.exception.ParameterException;
 
@@ -164,6 +165,43 @@ class UserServiceTest {
 				tuple(duplicatedEmail, DUPLICATED_EMAIL.getMessage())
 			);
 	}
+
+	@Test
+	@DisplayName("getUserByUsername(유저네임): 유저네임을 받아 사용자를 조회한다.")
+	void getUserByUsername_success() {
+		// given
+		final String username = "testerId";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		saveUser(username, nickname, email);
+
+		// when
+		User result = userService.getUserByUsername(username);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getUsername()).isEqualTo(username);
+		assertThat(result.getNickname()).isEqualTo(nickname);
+		assertThat(result.getEmail()).isEqualTo(email);
+	}
+
+	@Test
+	@DisplayName("getUserByUsername(유저네임): 유저네임이 존재하지 않는 경우 조회에 실패한다.")
+	void getUserByUsername_does_not_exist_username_fail() {
+		// given
+		final String username = "testerId";
+		final String nickname = "tester";
+		final String email = "tester@gmail.com";
+		saveUser(username, nickname, email);
+
+		final String newUsername = "newUsername";
+
+		// expected
+		assertThatThrownBy(() -> userService.getUserByUsername(newUsername))
+			.isInstanceOf(CustomException.class)
+			.hasMessage(USER_NOT_FOUND.getMessage());
+	}
+
 	
 	private User saveUser(String username, String nickname, String email) {
 		return userRepository.save(User.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13

## 📝작업 내용

- CustomAuthenticationProvider 정의
- UserRepository, UserService 유저 조회 기능 추가 및 테스트 코드 구현
- HttpSecurity에 CustomAuthenticationProvider 등록

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
