### PR TITLE
[feat] 가게 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/nanglangeats/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/image/repository/ImageRepository.java
@@ -9,4 +9,6 @@ import com.sparta.nanglangeats.domain.image.enums.ImageCategory;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findAllByImageCategoryAndAndContentId(ImageCategory imageCategory, Long contentId);
+
+	List<Image> findByContentIdInAndImageCategory(List<Long> contentId, ImageCategory imageCategory);
 }

--- a/src/main/java/com/sparta/nanglangeats/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/controller/StoreController.java
@@ -1,5 +1,10 @@
 package com.sparta.nanglangeats.domain.store.controller;
 
+import static com.sparta.nanglangeats.global.common.util.ControllerUtil.*;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -11,18 +16,18 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sparta.nanglangeats.domain.store.controller.dto.request.StoreRequest;
 import com.sparta.nanglangeats.domain.store.service.StoreService;
 import com.sparta.nanglangeats.domain.user.entity.User;
 import com.sparta.nanglangeats.global.common.dto.CommonResponse;
+import com.sparta.nanglangeats.global.common.exception.CustomException;
+import com.sparta.nanglangeats.global.common.exception.ErrorCode;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
-import static com.sparta.nanglangeats.global.common.util.ControllerUtil.getResponseEntity;
-import static com.sparta.nanglangeats.global.common.util.ControllerUtil.getOkResponseEntity;
 
 @RestController
 @RequiredArgsConstructor
@@ -59,5 +64,23 @@ public class StoreController {
 	public ResponseEntity<CommonResponse<?>> getStoreDetail(
 		@PathVariable String uuid) {
 		return getOkResponseEntity(storeService.getStoreDetail(uuid), "가게 상세 조회 완료");
+	}
+
+	@GetMapping
+	public ResponseEntity<CommonResponse<?>> getStoresList(
+		@RequestParam Long categoryId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size,
+		@RequestParam(defaultValue = "name") String sortBy) {
+		List<String> validSortByFields = Arrays.asList("name", "reviewCount", "rating");
+		if (!validSortByFields.contains(sortBy))
+			throw new CustomException(ErrorCode.INVALID_SORTBY_PARAMETER);
+
+		String direction = "desc";
+		if (sortBy.equals("name"))
+			direction = "asc";
+
+		return getOkResponseEntity(storeService.getStoresList(categoryId, page, size, sortBy, direction),
+			"가게 목록 조회 완료");
 	}
 }

--- a/src/main/java/com/sparta/nanglangeats/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/controller/StoreController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,21 +37,27 @@ public class StoreController {
 		return getResponseEntity(HttpStatus.CREATED, storeService.createStore(request), "가게 등록 완료");
 	}
 
-	@PutMapping("/{storeId}")
+	@PutMapping("/{uuid}")
 	@PreAuthorize("hasAnyRole('OWNER')")
 	public ResponseEntity<CommonResponse<?>> updateStore(
-		@PathVariable Long storeId,
+		@PathVariable String uuid,
 		@ModelAttribute StoreRequest request,
-		@AuthenticationPrincipal User user){
-		return getOkResponseEntity(storeService.updateStore(storeId, request, user), "가게 수정 완료");
+		@AuthenticationPrincipal User user) {
+		return getOkResponseEntity(storeService.updateStore(uuid, request, user), "가게 수정 완료");
 	}
 
-	@DeleteMapping("/{storeId}")
+	@DeleteMapping("/{uuid}")
 	@PreAuthorize("hasAnyRole('OWNER')")
 	public ResponseEntity<CommonResponse<?>> deleteStore(
-		@PathVariable Long storeId,
-		@AuthenticationPrincipal User user){
-		storeService.deleteStore(storeId, user);
+		@PathVariable String uuid,
+		@AuthenticationPrincipal User user) {
+		storeService.deleteStore(uuid, user);
 		return getResponseEntity(HttpStatus.NO_CONTENT, null, "가게 삭제 완료");
+	}
+
+	@GetMapping("/{uuid}")
+	public ResponseEntity<CommonResponse<?>> getStoreDetail(
+		@PathVariable String uuid) {
+		return getOkResponseEntity(storeService.getStoreDetail(uuid), "가게 상세 조회 완료");
 	}
 }

--- a/src/main/java/com/sparta/nanglangeats/domain/store/controller/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/controller/dto/response/StoreDetailResponse.java
@@ -1,0 +1,35 @@
+package com.sparta.nanglangeats.domain.store.controller.dto.response;
+
+import java.time.LocalTime;
+
+import com.sparta.nanglangeats.domain.store.entity.Category;
+import com.sparta.nanglangeats.domain.store.entity.Store;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StoreDetailResponse {
+	private final String category;
+	private final String owner;
+	private final String name;
+	private final String openTime;
+	private final String closeTime;
+	private final String address;
+	private final String phoneNumber;
+	private final Float rating;
+	private final Integer reviewCount;
+
+	@Builder
+	public StoreDetailResponse(Store store){
+		this.category = store.getCategory().getName();
+		this.owner=store.getOwner().getUsername();
+		this.name = store.getName();
+		this.openTime = store.getOpenTime().toString();
+		this.closeTime = store.getCloseTime().toString();
+		this.address=store.getCommonAddress().getAddress() + " " + store.getAddressDetail();
+		this.phoneNumber=store.getPhoneNumber();
+		this.rating=store.getRating();
+		this.reviewCount=store.getReviewCount();
+	}
+}

--- a/src/main/java/com/sparta/nanglangeats/domain/store/controller/dto/response/StoreListResponse.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/controller/dto/response/StoreListResponse.java
@@ -1,0 +1,16 @@
+package com.sparta.nanglangeats.domain.store.controller.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreListResponse {
+	private final String uuid;
+	private final String name;
+	private final Float rating;
+	private final Integer reviewCount;
+	private final List<String> imagesUrl;
+}

--- a/src/main/java/com/sparta/nanglangeats/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/repository/StoreRepository.java
@@ -1,8 +1,11 @@
 package com.sparta.nanglangeats.domain.store.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.nanglangeats.domain.store.entity.Store;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+	Optional<Store> findByUuid(String uuid);
 }

--- a/src/main/java/com/sparta/nanglangeats/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/repository/StoreRepository.java
@@ -2,10 +2,14 @@ package com.sparta.nanglangeats.domain.store.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.nanglangeats.domain.store.entity.Store;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 	Optional<Store> findByUuid(String uuid);
+
+	Page<Store> findAllByCategoryId(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/nanglangeats/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/service/StoreService.java
@@ -11,6 +11,7 @@ import com.sparta.nanglangeats.domain.image.enums.ImageCategory;
 import com.sparta.nanglangeats.domain.image.repository.ImageRepository;
 import com.sparta.nanglangeats.domain.image.service.dto.ImageService;
 import com.sparta.nanglangeats.domain.store.controller.dto.request.StoreRequest;
+import com.sparta.nanglangeats.domain.store.controller.dto.response.StoreDetailResponse;
 import com.sparta.nanglangeats.domain.store.controller.dto.response.StoreResponse;
 import com.sparta.nanglangeats.domain.store.entity.Category;
 import com.sparta.nanglangeats.domain.store.entity.Store;
@@ -62,8 +63,8 @@ public class StoreService {
 	}
 
 	@Transactional
-	public StoreResponse updateStore(Long storeId, StoreRequest request, User user) {
-		Store store = findStoreById(storeId);
+	public StoreResponse updateStore(String uuid, StoreRequest request, User user) {
+		Store store = findStoreByUuid(uuid);
 
 		if (user.getRole().equals(UserRole.OWNER) && !store.getOwner().equals(user))
 			throw new CustomException(ErrorCode.ACCESS_DENIED);
@@ -79,13 +80,18 @@ public class StoreService {
 	}
 
 	@Transactional
-	public void deleteStore(Long storeId, User user) {
-		Store store = findStoreById(storeId);
+	public void deleteStore(String uuid, User user) {
+		Store store = findStoreByUuid(uuid);
 
 		if (user.getRole().equals(UserRole.OWNER) && !store.getOwner().equals(user))
 			throw new CustomException(ErrorCode.ACCESS_DENIED);
 
 		store.delete(user.getUsername());
+	}
+
+	public StoreDetailResponse getStoreDetail(String uuid){
+		Store store = findStoreByUuid(uuid);
+		return null;
 	}
 
 	/* UTIL */
@@ -100,7 +106,7 @@ public class StoreService {
 		return categoryRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
 	}
 
-	private Store findStoreById(Long id) {
-		return storeRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+	private Store findStoreByUuid(String uuid) {
+		return storeRepository.findByUuid(uuid).orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/sparta/nanglangeats/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/service/StoreService.java
@@ -91,7 +91,7 @@ public class StoreService {
 
 	public StoreDetailResponse getStoreDetail(String uuid){
 		Store store = findStoreByUuid(uuid);
-		return null;
+		return StoreDetailResponse.builder().store(store).build();
 	}
 
 	/* UTIL */

--- a/src/main/java/com/sparta/nanglangeats/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/nanglangeats/domain/store/service/StoreService.java
@@ -1,8 +1,17 @@
 package com.sparta.nanglangeats.domain.store.service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.sparta.nanglangeats.domain.address.entity.CommonAddress;
 import com.sparta.nanglangeats.domain.address.service.CommonAddressService;
@@ -12,6 +21,7 @@ import com.sparta.nanglangeats.domain.image.repository.ImageRepository;
 import com.sparta.nanglangeats.domain.image.service.dto.ImageService;
 import com.sparta.nanglangeats.domain.store.controller.dto.request.StoreRequest;
 import com.sparta.nanglangeats.domain.store.controller.dto.response.StoreDetailResponse;
+import com.sparta.nanglangeats.domain.store.controller.dto.response.StoreListResponse;
 import com.sparta.nanglangeats.domain.store.controller.dto.response.StoreResponse;
 import com.sparta.nanglangeats.domain.store.entity.Category;
 import com.sparta.nanglangeats.domain.store.entity.Store;
@@ -92,6 +102,38 @@ public class StoreService {
 	public StoreDetailResponse getStoreDetail(String uuid){
 		Store store = findStoreByUuid(uuid);
 		return StoreDetailResponse.builder().store(store).build();
+	}
+
+	public Page<StoreListResponse> getStoresList(Long categoryId, int page, int size, String sortBy, String direction) {
+		Sort sort = Sort.by(Sort.Direction.fromString(direction), sortBy);
+		Pageable pageable = PageRequest.of(page, size, sort);
+
+		Page<Store> stores = storeRepository.findAllByCategoryId(categoryId, pageable);
+
+		List<Long> storeIds = stores.stream()
+			.map(Store::getId)
+			.toList();
+
+		List<Image> images = imageRepository.findByContentIdInAndImageCategory(storeIds, ImageCategory.STORE_IMAGE);
+
+		Map<Long, List<String>> imageUrlMap = images.stream()
+			.collect(Collectors.groupingBy(
+				Image::getContentId,
+				Collectors.mapping(Image::getUrl, Collectors.toList())
+			));
+
+		// Store 엔티티와 이미지 리스트 매핑
+		List<StoreListResponse> storeResponses = stores.stream()
+			.map(store -> new StoreListResponse(
+				store.getUuid(),
+				store.getName(),
+				store.getRating(),
+				store.getReviewCount(),
+				imageUrlMap.getOrDefault(store.getId(), Collections.emptyList()) // 해당 Store의 이미지 리스트
+			))
+			.toList();
+
+		return new PageImpl<>(storeResponses, pageable, stores.getTotalElements());
 	}
 
 	/* UTIL */

--- a/src/main/java/com/sparta/nanglangeats/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/nanglangeats/global/common/exception/ErrorCode.java
@@ -1,10 +1,11 @@
 package com.sparta.nanglangeats.global.common.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import static org.springframework.http.HttpStatus.*;
+
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
@@ -12,6 +13,7 @@ public enum ErrorCode {
 
     // COMMON
     COMMON_INVALID_PARAMETER(BAD_REQUEST, "요청한 값이 올바르지 않습니다."),
+    INVALID_SORTBY_PARAMETER(BAD_REQUEST, "유효하지 않은 정렬 기준입니다."),
 
     // JWT
     INVALID_REFRESH_TOKEN(UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다. 다시 로그인 해주세요."),

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -9,6 +9,7 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: create-drop
+    show-sql: true
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## #️⃣연관된 이슈

> #54 

## 📝작업 내용

- 클라이언트로 공개하는 키가 uuid이기 때문에 요청을 받을 때에도 uuid로 받도록 수정
- application 파일 수정하여 수행되는 쿼리 출력하도록 함
- 가게 상세 정보 조회 기능 구현
- 가게 목록 조회 기능 구현 -> 카테고리 필수 선택, 정렬 기준 선택 가능(상호명순, 리뷰많은순, 별점높은순)